### PR TITLE
fix: Vercel Preview 배포 비활성화

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `vercel.json` 추가하여 main 브랜치만 배포되도록 설정
- PR Preview 배포 시 Supabase 환경변수 없어서 빌드 실패하던 문제 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)